### PR TITLE
CW-461: VitalQIP Terraform Integration feedback

### DIFF
--- a/docs/data-sources/rr.md
+++ b/docs/data-sources/rr.md
@@ -24,7 +24,7 @@ Use the `vitalqip_rr` data source to retrieve information for a Resource Record 
   * IDSN: Integrated Services Digital Network
   * SRV: Server Resource Record
   * X25: PSDN (Public Switched Data Network) address
-  * TXT_DKIM: Test DKIM
+  * TXT_DKIM: Text DKIM
   * CAA: Certification Authority Authorization
   * TLSA: TLS Authentication
   * NAPTR: Naming Authority Pointer

--- a/docs/resources/ipv6_subnet.md
+++ b/docs/resources/ipv6_subnet.md
@@ -12,7 +12,7 @@ The following list describes the parameters you can define in the resource block
 * `block_address` - `string`: **required**, IPv6 address of block.
 * `block_prefix_length` - `int`: **required**, Prefix length of block.
 * `create_reverse_zone` - `boolean`: **required**, Create Reverse Zone.
-* `subnet_name` - `string`: **optional**, Name of subnet.
+* `subnet_name` - `string`: **required**, Name of subnet.
 * `pool_name` - `string`: **optional**, Name of pool.
 * `block_name` - `string`: **optional**, Name of block.
 

--- a/docs/resources/rr.md
+++ b/docs/resources/rr.md
@@ -28,7 +28,7 @@ The following list describes the parameters you can define in the Resource Recor
   * IDSN: Integrated Services Digital Network
   * SRV: Server Resource Record
   * X25: PSDN (Public Switched Data Network) address
-  * TXT_DKIM: Test DKIM
+  * TXT_DKIM: Text DKIM
   * CAA: Certification Authority Authorization
   * TLSA: TLS Authentication
   * NAPTR: Naming Authority Pointer

--- a/vitalqip/entities/ipv6_address.go
+++ b/vitalqip/entities/ipv6_address.go
@@ -23,7 +23,7 @@ type IPv6Address struct {
 	NodeName       string `json:"nodeName,omitempty"`
 	UniqueID       string `json:"uniqueId,omitempty"`
 	DUID           string `json:"duid,omitempty"`
-	UseMACAddress  bool   `json:"useMACAddress,omitempty"`
+	UseMACAddress  bool   `json:"useMACAddress"`
 	MACAddress     string `json:"macAddress,omitempty"`
 	ObjectAddr     string `json:"objectAddr,omitempty"`
 	AddressVersion int    `json:"addressVersion,omitempty"`

--- a/vitalqip/entities/ipv6_subnet.go
+++ b/vitalqip/entities/ipv6_subnet.go
@@ -18,7 +18,7 @@ type IPv6Subnet struct {
 	SubnetName         string `json:"subnetName,omitempty"`
 	CreateSubnet       string `json:"createSubnet,omitempty"`
 	AlgorithmType      string `json:"algorithmType,omitempty"`
-	CreateReverseZone  bool   `json:"createReverseZone,omitempty"`
+	CreateReverseZone  bool   `json:"createReverseZone"`
 }
 
 func (s IPv6Subnet) String() string {


### PR DESCRIPTION
**1. Add  IPv6 subnet**

Actual behavior: when we create an IPv6 subnet with “create_reverse_zone = false”:

```
resource "vitalqip_ipv6_subnet" "ipv6_subnet" {
	  // required parameters
	  org_name             = "CAA-test"
	  subnet_address       = "fd00:20:25::10:0"
	  subnet_name          = "Add v6 subnet"
	  subnet_prefix_length = 112
	  block_address        = "fd00:20:25::"
	  block_prefix_length  = 64
	  create_reverse_zone  = false
	  // optional parameters
	  pool_name  = "caa-terraform"
	  block_name = "Terraform-provider"
}
```

The “createReverseZone: true“ flag does not exist in CAA add subnet body:

```
{
	  "orgName": "CAA-test",
	  "addressVersion": 6,
	  "subnetAddress": "fd00:20:25::10:0",
	  "poolName": "caa-terraform",
	  "blockName": "Terraform-provider",
	  "blockAddress": "fd00:20:25::",
	  "prefixLength": 64,
	  "subnetPrefixLength": 112,
	  "subnetName": "Add v6 subnet",
	  "createSubnet": "SPECIFIC",
	  "algorithmType": "BEST_FIT_FROM_START"
}
```

 Then it raise an error like this: “error.addsubnet:No value specified for: [createReverseZone]”.

Expected results: it should put the “createReverseZone: false“ to CAA add subnet body.

**2. IPv6 Subnet resource document**

subnet_name - string: optional, Name of subnet. >> it should be “subnet_name - string: required, Name of subnet.“

Resource record resource/ data source document

**3. TXT_DKIM: Test DKIM >> it should be “TXT_DKIM: Text DKIM”**