### PR TITLE
CW-538: Terraform for QIP Zone feedback

### DIFF
--- a/docs/data-sources/zone.md
+++ b/docs/data-sources/zone.md
@@ -23,8 +23,8 @@ Use the `vitalqip_zone` data source to retrieve information for a Zone managed b
 * `udas` - `set`: **optional**, List of UDAs.
     * `name` - `string`: **optional**, Name of the UDA.
     * `value` - `string`: **optional**, Value of the UDA.
-* `groups` - `set`: **optional**, List of groups UDA.
-    * `name` - `string`: **optional**, Name of the group.
+* `groups` - `set`: **optional**, List of UDA groups.
+    * `name` - `string`: **optional**, Name of the UDA group.
     * `udas` - `set`: **optional**, List of UDAs.
         * `name` - `string`: **optional**, Name of the UDA.
         * `value` - `string`: **optional**, Value of the UDA.

--- a/docs/resources/zone.md
+++ b/docs/resources/zone.md
@@ -27,8 +27,8 @@ The following list describes the parameters you can define in the Zone of the re
 * `udas` - `set`: **optional**, List of UDAs.
     * `name` - `string`: **optional**, Name of the UDA.
     * `value` - `string`: **optional**, Value of the UDA.
-* `groups` - `set`: **optional**, List of groups UDA.
-    * `name` - `string`: **optional**, Name of the group.
+* `groups` - `set`: **optional**, List of UDA groups.
+    * `name` - `string`: **optional**, Name of the UDA group.
     * `udas` - `set`: **optional**, List of UDAs.
         * `name` - `string`: **optional**, Name of the UDA.
         * `value` - `string`: **optional**, Value of the UDA.

--- a/vitalqip/datasource_zone.go
+++ b/vitalqip/datasource_zone.go
@@ -157,14 +157,14 @@ func dataSourceZone() *schema.Resource {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Computed:    true,
-				Description: "List of groups UDA.",
+				Description: "List of UDA groups.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Computed:    true,
-							Description: "Name of the group.",
+							Description: "Name of the UDA group.",
 						},
 						"udas": {
 							Type:        schema.TypeSet,

--- a/vitalqip/entities/zone.go
+++ b/vitalqip/entities/zone.go
@@ -114,3 +114,9 @@ func NewZone(sb Zone) *Zone {
 	res.objectType = "zone"
 	return &res
 }
+
+type ZoneResponse struct {
+	PassNumber       int      `json:"passNumber,omitempty"`
+	FailedNumber     int      `json:"failedNumber,omitempty"`
+	ErrorDetailsList []string `json:"errorDetailsList,omitempty"`
+}

--- a/vitalqip/resource_zone.go
+++ b/vitalqip/resource_zone.go
@@ -155,14 +155,14 @@ func resourceZone() *schema.Resource {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Computed:    true,
-				Description: "List of groups UDA.",
+				Description: "List of UDA groups.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Computed:    true,
-							Description: "Name of the group.",
+							Description: "Name of the UDA group.",
 						},
 						"udas": {
 							Type:        schema.TypeSet,

--- a/vitalqip/utils/object_manager_zone.go
+++ b/vitalqip/utils/object_manager_zone.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"encoding/json"
+	"fmt"
 	en "terraform-provider-vitalqip/vitalqip/entities"
 )
 
@@ -30,9 +32,21 @@ func (objMgr *ObjectManager) DeleteZone(query map[string]string) error {
 
 func (objMgr *ObjectManager) UpdateZone(zone *en.ZoneUpdate) error {
 
-	_, err := objMgr.connector.UpdateObject(zone, "qipmodifyzone")
+	jsonString, err := objMgr.connector.UpdateObject(zone, "qipmodifyzone")
 	if err != nil {
 		return err
 	}
+
+	var zoneResponse en.ZoneResponse
+
+	errParseJson := json.Unmarshal([]byte(jsonString), &zoneResponse)
+	if errParseJson != nil {
+		return errParseJson
+	}
+
+	if zoneResponse.FailedNumber == 1 && len(zoneResponse.ErrorDetailsList) > 0 {
+		return fmt.Errorf(zoneResponse.ErrorDetailsList[0])
+	}
+
 	return nil
 }


### PR DESCRIPTION
**1. vitalqip_zone data source and resouce document**

- groups - set: optional, List of groups UDA. > groups - set: optional, List of UDA groups.

- name - string: optional, Name of the group. > name - string: optional, Name of the UDA group.

**2. Modify zone in unhappy cases**

- Actual results: when we ran to unhappy cases, CAA may return {"passNumber":0,"failedNumber":1,"errorDetailsList":["<error_message>"]} with status code 200 then Terraform return that it changed the zone while it did not changed any thing in QIP.

- Expected results: it should return the error message from the response from CAA and not modify the .tfstate file.

